### PR TITLE
Reset value on every loop iteration.

### DIFF
--- a/lib/CHH/Optparse.php
+++ b/lib/CHH/Optparse.php
@@ -146,6 +146,9 @@ class Parser implements \ArrayAccess
         }
 
         foreach ($args as $pos => $arg) {
+            // reset value
+            $value = NULL;
+
             if (substr($arg, 0, 1) === '-') {
                 if (preg_match('/^(.+)=(.+)$/', $arg, $matches)) {
                     $arg = $matches[1];


### PR DESCRIPTION
Hi,

this pr fixes misparing of opts like: ./application -t 3 -s 7 -p 1337 -a 42

Value needs to be resettet on every iteration, or it is not resettet.

Thanks
Valentin
